### PR TITLE
Implement writer for nodes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,8 +20,10 @@ import "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 const (
 	// KeyURI is a config field name for a connection URI.
 	KeyURI = "uri"
-	// KeyKeyProperties is a config field name for a key properties.
-	KeyKeyProperties = "keyProperties"
+	// KeyEntityType is a config field name for a entity type.
+	KeyEntityType = "entityType"
+	// KeyEntityLabels is a config field name for entity labels.
+	KeyEntityLabels = "entityLabels"
 	// KeyDatabase is a config field name for a database.
 	KeyDatabase = "database"
 	// KeyAuthUsername is a config field name for a basic auth username.
@@ -32,14 +34,23 @@ const (
 	KeyAuthRealm = "auth.realm"
 )
 
+// EntityType defines a Neo4j entity type.
+type EntityType string
+
+// The available entity types are listed below.
+const (
+	EntityTypeNode         = "node"
+	EntityTypeRelationship = "relationship"
+)
+
 // Config holds configurable values shared between Source and Destination.
 type Config struct {
 	// The connection URI pointed to a Neo4j instance.
 	URI string `json:"uri" validate:"required"`
-	// The comma separated list of column names to
-	// build a WHERE clause in case sdk.Record.Key is empty (destination) or
-	// build an sdk.Record.Key (source).
-	KeyProperties []string `json:"keyProperties" validate:"required"`
+	// Defines an entity type the connector should work with.
+	EntityType EntityType `json:"entityType" validate:"required,inclusion=node|relationship"`
+	// Holds a list of labels belonging to an entity.
+	EntityLabels []string `json:"entityLabels" validate:"required"`
 	// The name of a database the connector should work with.
 	Database string `json:"database" default:"neo4j"`
 	// Auth holds auth-specific configurable values.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,17 +33,19 @@ func TestParseConfig(t *testing.T) {
 		{
 			name: "success",
 			raw: map[string]string{
-				KeyURI:           "http://localhost:33575",
-				KeyKeyProperties: "id,created_at",
-				KeyDatabase:      "neo4j",
-				KeyAuthUsername:  "admin",
-				KeyAuthPassword:  "secret",
-				KeyAuthRealm:     "realm",
+				KeyURI:          "http://localhost:33575",
+				KeyEntityType:   "node",
+				KeyEntityLabels: "Person,Worker",
+				KeyDatabase:     "neo4j",
+				KeyAuthUsername: "admin",
+				KeyAuthPassword: "secret",
+				KeyAuthRealm:    "realm",
 			},
 			want: Config{
-				URI:           "http://localhost:33575",
-				KeyProperties: []string{"id", "created_at"},
-				Database:      "neo4j",
+				URI:          "http://localhost:33575",
+				EntityType:   EntityTypeNode,
+				EntityLabels: []string{"Person", "Worker"},
+				Database:     "neo4j",
 				Auth: AuthConfig{
 					Username: "admin",
 					Password: "secret",

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/conduitio-labs/conduit-connector-neo4j/destination/writer"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
@@ -68,6 +69,12 @@ func (d *Destination) Open(ctx context.Context) error {
 	}
 
 	d.driver = driver
+	d.writer = writer.New(writer.Params{
+		Driver:       d.driver,
+		DatabaseName: d.config.Database,
+		EntityType:   d.config.EntityType,
+		EntityLabels: d.config.EntityLabels,
+	})
 
 	return nil
 }

--- a/destination/destination_params.go
+++ b/destination/destination_params.go
@@ -33,12 +33,21 @@ func (Config) Parameters() map[string]sdk.Parameter {
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},
-		"keyProperties": {
+		"entityLabels": {
 			Default:     "",
-			Description: "The comma separated list of column names to build a WHERE clause in case sdk.Record.Key is empty (destination) or build an sdk.Record.Key (source).",
+			Description: "Holds a list of labels belonging to an entity.",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
+			},
+		},
+		"entityType": {
+			Default:     "",
+			Description: "Defines an entity type the connector should work with.",
+			Type:        sdk.ParameterTypeString,
+			Validations: []sdk.Validation{
+				sdk.ValidationRequired{},
+				sdk.ValidationInclusion{List: []string{"node", "relationship"}},
 			},
 		},
 		"uri": {

--- a/destination/writer/writer.go
+++ b/destination/writer/writer.go
@@ -1,0 +1,265 @@
+// Copyright © 2023 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package writer implements a writer logic for the Neo4j Destination.
+package writer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/conduitio-labs/conduit-connector-neo4j/config"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+const (
+	// all Cypher queries used by the [Writer] are listed below in the format of Go fmt.
+	createNodeQueryTemplate = "CREATE (node:%s {%s})"
+	updateNodeQueryTemplate = "MATCH (node:%s {%s}) SET %s"
+	deleteNodeQueryTemplate = "MATCH (node:%s {%s}) DELETE node"
+
+	// some helper symbols for Cypher queries.
+	setKeyPrefix      = "node."
+	setAssignSign     = "="
+	matchAssignSign   = ":"
+	interpolationSign = "$"
+)
+
+// ErrEmptyRawData occurs when trying to structurize empty [sdk.RawData].
+var ErrEmptyRawData = errors.New("raw data is empty")
+
+// Writer implements a writer logic for the Neo4j Destination.
+type Writer struct {
+	driver       neo4j.DriverWithContext
+	databaseName string
+	entityType   config.EntityType
+	entityLabels string
+}
+
+// Params holds incoming params for the [Writer].
+type Params struct {
+	Driver       neo4j.DriverWithContext
+	DatabaseName string
+	EntityType   config.EntityType
+	EntityLabels []string
+}
+
+// New creates a new instance of the [Writer].
+func New(params Params) *Writer {
+	return &Writer{
+		driver:       params.Driver,
+		databaseName: params.DatabaseName,
+		entityType:   params.EntityType,
+		// join entity labels here to not do this each time constructing queries
+		entityLabels: strings.Join(params.EntityLabels, ":"),
+	}
+}
+
+// Write writes a record to the destination.
+func (w *Writer) Write(ctx context.Context, record sdk.Record) error {
+	err := sdk.Util.Destination.Route(ctx, record,
+		w.handleCreate,
+		w.handleUpdate,
+		w.handleDelete,
+		w.handleCreate,
+	)
+	if err != nil {
+		return fmt.Errorf("route record: %w", err)
+	}
+
+	return nil
+}
+
+func (w *Writer) handleCreate(ctx context.Context, record sdk.Record) error {
+	session := w.driver.NewSession(ctx, neo4j.SessionConfig{
+		DatabaseName: w.databaseName,
+	})
+	defer session.Close(ctx)
+
+	properties, err := w.structurizeRawData(record.Payload.After.Bytes())
+	if err != nil {
+		return fmt.Errorf("structurize record payload: %w", err)
+	}
+
+	// construct a CREATE query
+	cypherMatchProperties, err := w.cypherMatchProperties(properties)
+	if err != nil {
+		return fmt.Errorf("create cypher match properties: %w", err)
+	}
+
+	query := fmt.Sprintf(createNodeQueryTemplate, w.entityLabels, cypherMatchProperties)
+
+	// execute the CREATE query
+	if err := w.executeWriteQuery(ctx, session, query, properties); err != nil {
+		return fmt.Errorf("execute write query: %w", err)
+	}
+
+	return nil
+}
+
+func (w *Writer) handleUpdate(ctx context.Context, record sdk.Record) error {
+	session := w.driver.NewSession(ctx, neo4j.SessionConfig{
+		DatabaseName: w.databaseName,
+	})
+	defer session.Close(ctx)
+
+	key, err := w.structurizeRawData(record.Key.Bytes())
+	if err != nil {
+		return fmt.Errorf("structurize record key: %w", err)
+	}
+
+	properties, err := w.structurizeRawData(record.Payload.After.Bytes())
+	if err != nil {
+		return fmt.Errorf("structurize record payload: %w", err)
+	}
+
+	// add keys to the properties map because we need them
+	// for interpolation within the executeWriteQuery method
+	// and to avoid creating a third map
+	for keyName, keyValue := range key {
+		if _, ok := properties[keyName]; !ok {
+			properties[keyName] = keyValue
+		}
+	}
+
+	// construct a MATCH SET query
+	cypherMatchProperties, err := w.cypherMatchProperties(key)
+	if err != nil {
+		return fmt.Errorf("create cypher match properties: %w", err)
+	}
+
+	cypherSetProperties, err := w.cypherSetProperties(properties, key)
+	if err != nil {
+		return fmt.Errorf("create cypher set properties: %w", err)
+	}
+
+	query := fmt.Sprintf(updateNodeQueryTemplate, w.entityLabels, cypherMatchProperties, cypherSetProperties)
+
+	// execute the MATCH SET query
+	if err := w.executeWriteQuery(ctx, session, query, properties); err != nil {
+		return fmt.Errorf("execute write query: %w", err)
+	}
+
+	return nil
+}
+
+func (w *Writer) handleDelete(ctx context.Context, record sdk.Record) error {
+	session := w.driver.NewSession(ctx, neo4j.SessionConfig{
+		DatabaseName: w.databaseName,
+	})
+	defer session.Close(ctx)
+
+	key, err := w.structurizeRawData(record.Key.Bytes())
+	if err != nil {
+		return fmt.Errorf("structurize record key: %w", err)
+	}
+
+	// construct a MATCH DELETE query
+	cypherMatchProperties, err := w.cypherMatchProperties(key)
+	if err != nil {
+		return fmt.Errorf("create cypher match properties: %w", err)
+	}
+
+	query := fmt.Sprintf(deleteNodeQueryTemplate, w.entityLabels, cypherMatchProperties)
+
+	// execute the MATCH DELETE query
+	if err := w.executeWriteQuery(ctx, session, query, key); err != nil {
+		return fmt.Errorf("execute write query: %w", err)
+	}
+
+	return nil
+}
+
+// structurizeRawData tries to unmarshal the [sdk.RawData]
+// and if the process fails or the [sdk.RawData] is empty the method returns an error.
+func (w *Writer) structurizeRawData(rawData sdk.RawData) (map[string]any, error) {
+	if rawData == nil || len(rawData.Bytes()) == 0 {
+		return nil, ErrEmptyRawData
+	}
+
+	var structurizedData map[string]any
+	if err := json.Unmarshal(rawData, &structurizedData); err != nil {
+		return nil, fmt.Errorf("unmarshal raw data: %w", err)
+	}
+
+	return structurizedData, nil
+}
+
+// executeWriteQuery is a helper method that wraps the [neo4j.ExecuteWrite] function
+// and the underlying anonymous function.
+func (w *Writer) executeWriteQuery(
+	ctx context.Context,
+	session neo4j.SessionWithContext,
+	query string,
+	properties map[string]any,
+) error {
+	_, err := neo4j.ExecuteWrite(ctx, session, func(tx neo4j.ManagedTransaction) (neo4j.ResultSummary, error) {
+		result, txErr := tx.Run(ctx, query, properties)
+		if txErr != nil {
+			return nil, fmt.Errorf("run tx: %w", txErr)
+		}
+
+		summary, err := result.Consume(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("consume result: %w", err)
+		}
+
+		return summary, nil
+	})
+	if err != nil {
+		return fmt.Errorf("execute write: %w", err)
+	}
+
+	return nil
+}
+
+// cypherMatchProperties constructs a set of properties
+// according to the Cypher MATCH syntax, e.g.: "{prop: $prop}".
+func (w *Writer) cypherMatchProperties(properties map[string]any) (string, error) {
+	var sb strings.Builder
+	for propertyName := range properties {
+		_, err := sb.WriteString(
+			propertyName + matchAssignSign + interpolationSign + propertyName + ", ",
+		)
+		if err != nil {
+			return "", fmt.Errorf("write string: %w", err)
+		}
+	}
+
+	return strings.TrimRight(sb.String(), ", "), nil
+}
+
+// cypherSetProperties constructs a set of properties
+// according to the Cypher SET syntax, e.g.: "prefix.prop = $prop".
+func (w *Writer) cypherSetProperties(properties map[string]any, key map[string]any) (string, error) {
+	var sb strings.Builder
+	for propertyName := range properties {
+		if _, ok := key[propertyName]; ok {
+			continue
+		}
+
+		_, err := sb.WriteString(
+			setKeyPrefix + propertyName + setAssignSign + interpolationSign + propertyName + ", ",
+		)
+		if err != nil {
+			return "", fmt.Errorf("write string: %w", err)
+		}
+	}
+
+	return strings.TrimRight(sb.String(), ", "), nil
+}

--- a/destination/writer/writer_test.go
+++ b/destination/writer/writer_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2023 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writer
+
+import (
+	"testing"
+)
+
+func BenchmarkWriter_cypherMatchProperties(b *testing.B) {
+	var (
+		writer     = New(Params{})
+		properties = map[string]any{"name": "Alex", "age": 23}
+	)
+
+	for i := 0; i < b.N; i++ {
+		_, err := writer.cypherMatchProperties(properties)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWriter_cypherSetProperties(b *testing.B) {
+	var (
+		writer     = New(Params{})
+		key        = map[string]any{"_id": 1}
+		properties = map[string]any{"name": "Alex", "age": 23}
+	)
+
+	for i := 0; i < b.N; i++ {
+		_, err := writer.cypherSetProperties(properties, key)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/conduitio-labs/conduit-connector-neo4j
 go 1.19
 
 require (
-	github.com/conduitio/conduit-connector-sdk v0.4.2
+	github.com/conduitio/conduit-connector-sdk v0.4.3
 	github.com/golang/mock v1.6.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.4.0
 )
@@ -27,12 +27,12 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.2.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	golang.org/x/exp v0.0.0-20230111222715-75897c7a292a // indirect
+	golang.org/x/exp v0.0.0-20230118134722-a68e582fa157 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/genproto v0.0.0-20230117162540-28d6b9783ac4 // indirect
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/conduitio/conduit-connector-protocol v0.4.0 h1:hO6mB4Ft34+PbF1G2pDGHzZmCA/y5jj5wsIrluw4qFY=
 github.com/conduitio/conduit-connector-protocol v0.4.0/go.mod h1:xU4dsoPPCiW+1rJFwxkMUjhYs+HMte+XB/aFL6x94iM=
-github.com/conduitio/conduit-connector-sdk v0.4.2 h1:lwO7brO/Ildb3O9fzX+6qSV4VPUkiqgbywUSeFRi3Ns=
-github.com/conduitio/conduit-connector-sdk v0.4.2/go.mod h1:SNz/Sn4zNuJNMELlr+HVe8Br8SpDea0EB4Gmh+Ha0+k=
+github.com/conduitio/conduit-connector-sdk v0.4.3 h1:1PRbPWn4yWT3qtcGjcVE7hHiVnID+rY20x3b+SbM55I=
+github.com/conduitio/conduit-connector-sdk v0.4.3/go.mod h1:SNz/Sn4zNuJNMELlr+HVe8Br8SpDea0EB4Gmh+Ha0+k=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -81,8 +81,8 @@ go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTV
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230111222715-75897c7a292a h1:/YWeLOBWYV5WAQORVPkZF3Pq9IppkcT72GKnWjNf5W8=
-golang.org/x/exp v0.0.0-20230111222715-75897c7a292a/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230118134722-a68e582fa157 h1:fiNkyhJPUvxbRPbCqY/D9qdjmPzfHcpK3P4bM4gioSY=
+golang.org/x/exp v0.0.0-20230118134722-a68e582fa157/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -139,8 +139,8 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230117162540-28d6b9783ac4 h1:yF0uHwqqYt2tIL2F4hxRWA1ZFX43SEunWAK8MnQiclk=
+google.golang.org/genproto v0.0.0-20230117162540-28d6b9783ac4/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=


### PR DESCRIPTION
### Description

This patch seeks to implement `Writer` for Neo4j nodes. The `config.Config` has been updated, the `KeyProperties` field has been removed from it, and two new fields `EntityType` and `EntityLabels` have been added.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-neo4j/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
