### PR TITLE
Use `schema.Node` for nodes in the snapshot iterator

### DIFF
--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/conduitio-labs/conduit-connector-neo4j/config"
+	"github.com/conduitio-labs/conduit-connector-neo4j/schema"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
@@ -267,8 +268,8 @@ func (s *Snapshot) processNeo4jResult(ctx context.Context, result neo4j.ResultWi
 				return errConvertRawRelationship
 			}
 
-			props[sourceNodeField] = srcNode.Props
-			props[targetNodeField] = trgtNode.Props
+			props[sourceNodeField] = schema.Node{Labels: srcNode.Labels, Key: srcNode.Props}
+			props[targetNodeField] = schema.Node{Labels: trgtNode.Labels, Key: trgtNode.Props}
 		}
 
 		s.records <- props


### PR DESCRIPTION
### Description

This patch seeks to change the `source` and `target` nodes format that the snapshot iterator uses by utilizing the `schema.Node` structure.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-neo4j/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
