### PR TITLE
Ignore elements with null ordering property

### DIFF
--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -41,11 +41,11 @@ const (
 	RETURN obj.%s as %s ORDER BY obj.%s DESC LIMIT 1`
 
 	getNodesQueryTemplate = `
-	MATCH (obj:%s) WHERE %s
+	MATCH (obj:%s) WHERE obj.%s IS NOT NULL AND %s
 	RETURN obj ORDER BY obj.%s ASC LIMIT %d`
 
 	getRelationshipsQueryTemplate = `
-	MATCH (src)-[obj:%s]->(trgt) WHERE %s
+	MATCH (src)-[obj:%s]->(trgt) WHERE obj.%s IS NOT NULL AND %s
 	RETURN obj, src, trgt ORDER BY obj.%s ASC LIMIT %d`
 
 	opmvLTEWhereClause = "obj.%s <= $opmv"
@@ -275,7 +275,9 @@ func (s *Snapshot) loadBatch(ctx context.Context) error {
 		getQueryTemplate = getRelationshipsQueryTemplate
 	}
 
-	query := fmt.Sprintf(getQueryTemplate, s.entityLabels, whereClause, s.orderingProperty, s.batchSize)
+	query := fmt.Sprintf(
+		getQueryTemplate, s.entityLabels, s.orderingProperty, whereClause, s.orderingProperty, s.batchSize,
+	)
 
 	_, err := neo4j.ExecuteRead(ctx, session, func(tx neo4j.ManagedTransaction) (neo4j.ResultWithContext, error) {
 		result, err := tx.Run(ctx, query, params)


### PR DESCRIPTION
### Description

This PR seeks to update the snapshot iterator, so it ignores elements with null ordering property.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-neo4j/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
